### PR TITLE
Replace susy space by span function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 .sass-cache
 build
 dist
+
+# vim
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~

--- a/stylesheets/style.scss
+++ b/stylesheets/style.scss
@@ -181,7 +181,7 @@ section {
             content: "";
             display: inline-block;
             margin-right: gutter();
-            width: space(2) - gutter();
+            width: span(2) - gutter();
             height: rhythm($h2-line-multiple/3, $h2-font-size);
             margin-bottom: rhythm($h2-line-multiple/6, $h2-font-size);
             background-color: $section-rectangle-color;


### PR DESCRIPTION
This fix that the color bars befor the headlines does not appear with
susy version > 2

See: http://susydocs.oddbird.net/en/latest/upgrade/#functions
