### PR TITLE
Fixing an error I received from the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,8 @@ media: | directories
 html: media style templates/cv.html parts $(SRC_DIR)/cv.md | directories
 	pandoc --standalone \
 	  --section-divs \
-	  --smart \
 	  --template templates/cv.html \
-	  --from markdown+yaml_metadata_block+header_attributes+definition_lists \
+	  --from markdown+yaml_metadata_block+header_attributes+definition_lists+smart \
 	  --to html5 \
 	  $(before-body) \
 	  $(after-body) \


### PR DESCRIPTION
MacOS Version: 10.13.5
Pandoc Version:
pandoc 2.2.1
Compiled with pandoc-types 1.17.4.2, texmath 0.11, skylighting 0.7.1

When trying to run the makefile for your resume template, I received the following error. it looks like the --smart in the HTML section has been replaced by tacking the +smart extension onto the format. I think this should fix it and accomplish the same thing? Hope this helps.

Error:
"--smart/-S has been removed.  Use +smart or -smart extension instead."