### PR TITLE
Enables wkhtmltopdf local file access of distribution directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ pdf: html pdftags
 ifeq ($(HTMLTOPDF),wkpdf)
 	wkpdf --paper a4 --margins 30 --print-background yes --orientation portrait --stylesheet-media print --source $(DIST_DIR)/cv.html --output $(DIST_DIR)/cv.pdf
 else
-	wkhtmltopdf --print-media-type --orientation Portrait --page-size A4 --margin-top 15 --margin-left 15 --margin-right 15 --margin-bottom 15 --enable-local-file-access --disable-local-file-access --allow $(DIST_DIR) $(DIST_DIR)/cv.html $(DIST_DIR)/cv.pdf
+	wkhtmltopdf --print-media-type --orientation Portrait --page-size A4 --margin-top 15 --margin-left 15 --margin-right 15 --margin-bottom 15 --disable-local-file-access --allow $(DIST_DIR) $(DIST_DIR)/cv.html $(DIST_DIR)/cv.pdf
 endif
 	exiftool $(shell cat $(BUILD_DIR)/pdftags.txt) $(DIST_DIR)/cv.pdf
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ pdf: html pdftags
 ifeq ($(HTMLTOPDF),wkpdf)
 	wkpdf --paper a4 --margins 30 --print-background yes --orientation portrait --stylesheet-media print --source $(DIST_DIR)/cv.html --output $(DIST_DIR)/cv.pdf
 else
-	wkhtmltopdf --print-media-type --orientation Portrait --page-size A4 --margin-top 15 --margin-left 15 --margin-right 15 --margin-bottom 15 $(DIST_DIR)/cv.html $(DIST_DIR)/cv.pdf
+	wkhtmltopdf --print-media-type --orientation Portrait --page-size A4 --margin-top 15 --margin-left 15 --margin-right 15 --margin-bottom 15 --enable-local-file-access --disable-local-file-access --allow $(DIST_DIR) $(DIST_DIR)/cv.html $(DIST_DIR)/cv.pdf
 endif
 	exiftool $(shell cat $(BUILD_DIR)/pdftags.txt) $(DIST_DIR)/cv.pdf
 
@@ -120,4 +120,3 @@ $(PARTS): $(BUILD_DIR)/%.html: $(SRC_DIR)/%.md | directories
 clean:
 	rm -rf $(DIST_DIR)
 	rm -rf $(BUILD_DIR)
-


### PR DESCRIPTION
This PR enables wkhtmltopdf local file access. Particular of the distribution directory `$(DIST_DIR)`, because the default behavour in version 0.12.6 of wkhtmltopdf is to disable local file access. This changes that behavour. 